### PR TITLE
Async job try

### DIFF
--- a/article/pom.xml
+++ b/article/pom.xml
@@ -144,6 +144,10 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/article/src/main/java/org/example/article/entities/AsyncJob.java
+++ b/article/src/main/java/org/example/article/entities/AsyncJob.java
@@ -1,0 +1,44 @@
+package org.example.article.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Entity
+@Data
+public class AsyncJob {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // np. "RECALC_CYCLE_SCORES", "DELETE_MEIN_VERSION"
+    private String type;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Integer progressPercent;
+    private String phase;              // np. "Deleting journals", "Recalculating scores"
+    private String message;            // krótki opis dla UI
+    @Column(name = "business_key", length = 200)
+    private String businessKey;
+    @Column(columnDefinition = "text")
+    private String requestPayload;
+    @Column(columnDefinition = "text")
+    private String resultPayload;
+
+    private String errorMessage;
+
+    private Instant createdAt;
+    private Instant finishedAt;
+
+    public enum Status {
+        QUEUED,
+        RUNNING,
+        DONE,
+        FAILED
+    }
+
+}

--- a/article/src/main/java/org/example/article/entities/EvalCycle.java
+++ b/article/src/main/java/org/example/article/entities/EvalCycle.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import org.example.article.entities.MEiN.article.MeinVersion;
 import org.example.article.entities.MEiN.monographs.MeinMonoVersion;
+import org.hibernate.annotations.OnDelete;
 
 @Data
 @Entity

--- a/article/src/main/java/org/example/article/helpers/AsyncConfig.java
+++ b/article/src/main/java/org/example/article/helpers/AsyncConfig.java
@@ -1,0 +1,24 @@
+package org.example.article.helpers;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "meinTaskExecutor")
+    public Executor meinTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("MeinAsync-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/article/src/main/java/org/example/article/helpers/CommutePoints.java
+++ b/article/src/main/java/org/example/article/helpers/CommutePoints.java
@@ -42,7 +42,7 @@ public class CommutePoints {
         var cycle = evalCycleRepository.findByYear(year)
                 .orElseThrow(() -> new IllegalArgumentException("No eval cycle for year " + year));
         if (cycle.getMeinVersion() == null || cycle.getMeinVersion().getId() == null) {
-            throw new IllegalArgumentException("Eval cycle has no MEiN version");
+            return new CommuteResultArticle(cycle, null, null, 0, false);
         }
         Long versionId = cycle.getMeinVersion().getId();
 
@@ -88,7 +88,7 @@ public class CommutePoints {
         var cycle = evalCycleRepository.findByYear(year)
                 .orElseThrow(() -> new IllegalArgumentException("No eval cycle for year " + year));
         if (cycle.getMeinMonoVersion() == null || cycle.getMeinMonoVersion().getId() == null) {
-            throw new IllegalArgumentException("Eval cycle has no MEiN mono version");
+            return new CommuteResultMono(cycle, null, null, 0, false);
         }
 
         Long versionId = cycle.getMeinMonoVersion().getId();
@@ -119,7 +119,7 @@ public class CommutePoints {
         var cycle = evalCycleRepository.findByYear(year)
                 .orElseThrow(() -> new IllegalArgumentException("No eval cycle for year " + year));
         if(cycle.getMeinMonoVersion() == null || cycle.getMeinMonoVersion().getId() == null) {
-            throw new IllegalArgumentException("Eval cycle has no MEiN mono version");
+            return new CommuteResultMonoChapter(cycle, null, null, 0, false);
         }
         Long versionId = cycle.getMeinMonoVersion().getId();
 

--- a/article/src/main/java/org/example/article/helpers/Recalculation.java
+++ b/article/src/main/java/org/example/article/helpers/Recalculation.java
@@ -1,0 +1,11 @@
+package org.example.article.helpers;
+
+import lombok.Data;
+
+@Data
+public class Recalculation {
+    private int updatedMono;
+    private int updatedChapter;
+    private int unmatchdMono;
+    private int unmatchdChapter;
+}

--- a/article/src/main/java/org/example/article/repositories/AsyncJobRepository.java
+++ b/article/src/main/java/org/example/article/repositories/AsyncJobRepository.java
@@ -1,0 +1,15 @@
+package org.example.article.repositories;
+
+import org.example.article.entities.AsyncJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface AsyncJobRepository extends JpaRepository<AsyncJob, Long> {
+    Optional<AsyncJob> findFirstByTypeAndBusinessKeyAndStatusIn(
+            String type,
+            String businessKey,
+            Collection<AsyncJob.Status> statuses
+    );
+}

--- a/article/src/main/java/org/example/article/repositories/EvalCycleRepository.java
+++ b/article/src/main/java/org/example/article/repositories/EvalCycleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -35,7 +36,7 @@ public interface EvalCycleRepository extends JpaRepository<EvalCycle, Long> {
     boolean existsOverlappingExcludeId(@Param("id") long id, @Param("from") int yearFrom, @Param("to") int yearTo);
 
 
-
+    List<EvalCycle> findAllByMeinVersionId(Long versionId);
 
     @Modifying
     @Transactional
@@ -51,4 +52,10 @@ public interface EvalCycleRepository extends JpaRepository<EvalCycle, Long> {
       where c.isActive = true and c.id <> :id
     """)
     int deactivateAllExcept(@Param("id") long id);
+
+    @Query("""
+    SELECT c FROM EvalCycle c
+        WHERE c.meinMonoVersion.id = :versionId
+    """)
+    List<EvalCycle> findAllByMeinMonoVersion(@Param("versionId") long versionId);
 }

--- a/article/src/main/java/org/example/article/repositories/MeinMonoPublisherRepository.java
+++ b/article/src/main/java/org/example/article/repositories/MeinMonoPublisherRepository.java
@@ -1,6 +1,9 @@
 package org.example.article.repositories;
 
+import org.example.article.entities.MEiN.article.MeinJournal;
 import org.example.article.entities.MEiN.monographs.MeinMonoPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -20,10 +23,20 @@ public interface MeinMonoPublisherRepository extends JpaRepository<MeinMonoPubli
     """)
     Optional<MeinMonoPublisher> findByVersionIdAndTitle(@Param("versionId") Long versionId,@Param("name") String title);
 
+    Page<MeinMonoPublisher> findByVersion_Id(Long versionId, Pageable pageable);
+
     @Query("""
     SELECT (COUNT(p) > 0)
     FROM MeinMonoPublisher p
     WHERE p.version.id = :versionId and p.id = :publisherId
     """)
     boolean existsMatchInVersion(@Param("versionId") Long versionId, @Param("publisherId") Long publisherId);
+
+    @Query(value = """
+              SELECT COUNT(DISTINCT COALESCE(NULLIF(uid,'')))
+              FROM mein_mono_publisher
+              WHERE version_id = :versionId
+              """, nativeQuery = true)
+    long countPublishers(@Param("versionId") long versionId);
+
 }

--- a/article/src/main/java/org/example/article/repositories/MonographChapterRepository.java
+++ b/article/src/main/java/org/example/article/repositories/MonographChapterRepository.java
@@ -1,5 +1,6 @@
 package org.example.article.repositories;
 
+import org.example.article.entities.EvalCycle;
 import org.example.article.entities.MEiN.monographs.MonographChapter;
 import org.example.article.entities.MEiN.monographs.Monographic;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -30,5 +32,7 @@ public interface MonographChapterRepository extends JpaRepository<MonographChapt
     @EntityGraph(attributePaths = {"type", "discipline", "cycle", "coauthors"})
     Page<MonographChapter> findAll(Specification<MonographChapter> spec, Pageable pageable);
 
+    List<MonographChapter> findAllByCycle(EvalCycle cycle);
 
+    List<MonographChapter> findAllByMeinMonoId(Long meinMonoId);
 }

--- a/article/src/main/java/org/example/article/repositories/MonographicRepository.java
+++ b/article/src/main/java/org/example/article/repositories/MonographicRepository.java
@@ -1,5 +1,6 @@
 package org.example.article.repositories;
 
+import org.example.article.entities.EvalCycle;
 import org.example.article.entities.MEiN.monographs.Monographic;
 import org.example.article.entities.Publication;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,4 +35,7 @@ public interface MonographicRepository extends JpaRepository<Monographic, Long> 
     @EntityGraph(attributePaths = {"type", "discipline", "cycle", "coauthors"})
     Page<Monographic> findAll(Specification<Monographic> spec, Pageable pageable);
 
+    List<Monographic> findAllByCycle(EvalCycle cycleId);
+
+    List<Monographic> findAllByMeinMonoId(Long meinMonoId);
 }

--- a/article/src/main/java/org/example/article/repositories/PublicationRepository.java
+++ b/article/src/main/java/org/example/article/repositories/PublicationRepository.java
@@ -35,4 +35,5 @@ public interface PublicationRepository extends JpaRepository<Publication, Long>,
     Page<Publication> findAll(Specification<Publication> spec, Pageable pageable);
 
     List<Publication> findAllByCycle(EvalCycle cycleId);
+    List<Publication> findAllByMeinVersionId(Long meinVersionId);
 }

--- a/article/src/main/java/org/example/article/service/Async/AsyncArticleService.java
+++ b/article/src/main/java/org/example/article/service/Async/AsyncArticleService.java
@@ -1,0 +1,178 @@
+package org.example.article.service.Async;
+
+import org.example.article.entities.*;
+import org.example.article.entities.MEiN.monographs.MonographChapter;
+import org.example.article.entities.MEiN.monographs.Monographic;
+import org.example.article.helpers.CommutePoints;
+import org.example.article.helpers.Recalculation;
+import org.example.article.repositories.EvalCycleRepository;
+import org.example.article.repositories.MonographChapterRepository;
+import org.example.article.repositories.MonographicRepository;
+import org.example.article.repositories.PublicationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+@Service
+public class AsyncArticleService {
+
+    private final EvalCycleRepository evalCycleRepository;
+    private final PublicationRepository publicationRepository;
+    private final CommutePoints commutePoints;
+    private final MonographicRepository monographicRepository;
+    private final MonographChapterRepository monographChapterRepository;
+
+    public AsyncArticleService(EvalCycleRepository evalCycleRepository,
+                               PublicationRepository publicationRepository,
+                               CommutePoints commutePoints, MonographicRepository monographicRepository, MonographChapterRepository monographChapterRepository) {
+        this.evalCycleRepository = evalCycleRepository;
+        this.publicationRepository = publicationRepository;
+        this.commutePoints = commutePoints;
+        this.monographicRepository = monographicRepository;
+        this.monographChapterRepository = monographChapterRepository;
+    }
+
+    public record RecalcResult(int updated, int unmatched) {
+    }
+
+    /**
+     * Przelicza punkty dla cyklu.
+     * progressCallback może być null.
+     * progress: 0–100, phase: opis bieżącego etapu.
+     */
+    @Transactional
+    public RecalcResult recalcArticleCycleScores(
+            Long cycleId,
+            BiConsumer<Integer, String> progressCallback
+    ) {
+        EvalCycle evalCycle = evalCycleRepository.findById(cycleId)
+                .orElseThrow(() -> new RuntimeException("Not found the cycle"));
+
+        List<Publication> publications = publicationRepository.findAllByCycle(evalCycle);
+
+        int total = publications.size();
+        int processed = 0;
+        int updated = 0;
+        int unmatched = 0;
+
+        if (progressCallback != null) {
+            progressCallback.accept(0, "Starting article recalculation");
+        }
+
+        for (Publication pub : publications) {
+            CommuteResultArticle result = commutePoints.commuteArticle(
+                    pub.getJournalTitle(),
+                    pub.getType().getId(),
+                    pub.getDiscipline().getId(),
+                    pub.getIssn(),
+                    pub.getEissn(),
+                    pub.getPublicationYear()
+            );
+
+            if (result == null
+                    || result.meinJournal() == null
+                    || result.meinVersion() == null) {
+                unmatched++;
+            } else {
+                pub.setCycle(result.cycle());
+                pub.setMeinPoints(result.points());
+                pub.setMeinVersionId(result.meinVersion().getId());
+                pub.setMeinJournalId(result.meinJournal().getId());
+                pub.setUpdatedAt(Instant.now());
+                updated++;
+            }
+
+            processed++;
+
+            if (progressCallback != null && (processed % 10 == 0 || processed == total)) {
+                int percent = total == 0 ? 100 : (processed * 100 / total);
+                progressCallback.accept(percent,
+                        "Recalculating articles (" + processed + "/" + total + ")");
+            }
+        }
+
+        if (!publications.isEmpty()) {
+            publicationRepository.saveAll(publications);
+        }
+
+        if (progressCallback != null) {
+            progressCallback.accept(100, "Article recalculation finished");
+        }
+
+        return new RecalcResult(updated, unmatched);
+    }
+
+    public Recalculation recalcMonoCycleScoresInternal(EvalCycle evalCycle) {
+        List<Monographic> monographics = monographicRepository.findAllByCycle(evalCycle);
+        List<MonographChapter> chapters = monographChapterRepository.findAllByCycle(evalCycle);
+
+        int unmatchedMonograph = 0;
+        int unmatchedChapter = 0;
+        int updatedMonograph = 0;
+        int updatedChapter = 0;
+
+        for(MonographChapter mc : chapters){
+            CommuteResultMonoChapter resultMonoChapter = commutePoints.commuteChapter(
+                    mc.getMonographChapterPublisher(),
+                    mc.getType().getId(),
+                    mc.getPublicationYear()
+            );
+
+            if (resultMonoChapter == null
+                    || resultMonoChapter.meinMonoVersion() == null
+                    || resultMonoChapter.meinMonoPublisher() == null) {
+                unmatchedChapter++;
+                continue;
+            }
+
+            mc.setCycle(resultMonoChapter.cycle());
+            mc.setMeinPoints(resultMonoChapter.points());
+            mc.setMeinMonoId(resultMonoChapter.meinMonoVersion().getId());
+            mc.setMeinMonoPublisherId(resultMonoChapter.meinMonoPublisher().getId());
+            mc.setUpdatedAt(Instant.now());
+
+            updatedChapter++;
+
+            if(!chapters.isEmpty()){
+                monographChapterRepository.saveAll(chapters);
+            }
+        }
+
+        for(Monographic m : monographics){
+            CommuteResultMono resultMono = commutePoints.commuteMono(
+                    m.getMonograficTitle(),
+                    m.getType().getId(),
+                    m.getPublicationYear()
+            );
+
+            if (resultMono == null
+                    || resultMono.meinMonoVersion() == null
+                    || resultMono.meinMonoPublisher() == null) {
+                unmatchedMonograph++;
+                continue;
+            }
+
+            m.setCycle(resultMono.cycle());
+            m.setMeinPoints(resultMono.points());
+            m.setMeinMonoId(resultMono.meinMonoVersion().getId());
+            m.setMeinMonoPublisherId(resultMono.meinMonoPublisher().getId());
+            m.setUpdatedAt(Instant.now());
+
+            updatedMonograph++;
+
+            if(!monographics.isEmpty()){
+                monographicRepository.saveAll(monographics);
+            }
+        }
+
+        Recalculation recalculation = new Recalculation();
+        recalculation.setUnmatchdMono(unmatchedMonograph);
+        recalculation.setUnmatchdChapter(unmatchedChapter);
+        recalculation.setUpdatedMono(updatedMonograph);
+        recalculation.setUpdatedChapter(updatedChapter);
+        return recalculation;
+    }
+}

--- a/article/src/main/java/org/example/article/service/Async/AsyncMeinService.java
+++ b/article/src/main/java/org/example/article/service/Async/AsyncMeinService.java
@@ -1,0 +1,313 @@
+package org.example.article.service.Async;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.persistence.EntityManager;
+import org.example.article.entities.AsyncJob;
+import org.example.article.entities.EvalCycle;
+import org.example.article.entities.MEiN.monographs.MonographChapter;
+import org.example.article.entities.MEiN.monographs.Monographic;
+import org.example.article.entities.Publication;
+import org.example.article.helpers.CommutePoints;
+import org.example.article.helpers.Recalculation;
+import org.example.article.repositories.*;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+public class AsyncMeinService {
+
+    private final AsyncJobRepository asyncJobRepository;
+    private final AsyncArticleService articleService;
+    private final EvalCycleRepository evalCycleRepository;
+    private final PublicationRepository publicationRepository;
+    private final CommutePoints commutePoints;
+    private final MeinJournalCodeRepository meinJournalCodeRepository;
+    private final MeinJournalRepository meinJournalRepository;
+    private final MeinVersionRepository meinVersionRepository;
+    private final EntityManager entityManager;
+    private final TransactionTemplate tx;
+    private final ObjectMapper objectMapper;
+    private final MeinMonoVersionRepository meinMonoVersionRepository;
+    private final MonographChapterRepository monographChapterRepository;
+    private final MonographicRepository monographicRepository;
+
+    public AsyncMeinService(AsyncJobRepository asyncJobRepository,
+                            AsyncArticleService articleService,
+                            EvalCycleRepository evalCycleRepository,
+                            PublicationRepository publicationRepository,
+                            CommutePoints commutePoints,
+                            MeinJournalCodeRepository meinJournalCodeRepository,
+                            MeinJournalRepository meinJournalRepository,
+                            MeinVersionRepository meinVersionRepository,
+                            EntityManager entityManager,
+                            TransactionTemplate tx,
+                            ObjectMapper objectMapper, MeinMonoVersionRepository meinMonoVersionRepository, MonographChapterRepository monographChapterRepository, MonographicRepository monographicRepository) {
+        this.asyncJobRepository = asyncJobRepository;
+        this.articleService = articleService;
+        this.evalCycleRepository = evalCycleRepository;
+        this.publicationRepository = publicationRepository;
+        this.commutePoints = commutePoints;
+        this.meinJournalCodeRepository = meinJournalCodeRepository;
+        this.meinJournalRepository = meinJournalRepository;
+        this.meinVersionRepository = meinVersionRepository;
+        this.entityManager = entityManager;
+        this.tx = tx;
+        this.objectMapper = objectMapper;
+        this.meinMonoVersionRepository = meinMonoVersionRepository;
+        this.monographChapterRepository = monographChapterRepository;
+        this.monographicRepository = monographicRepository;
+    }
+
+    // 1) Job: RECALC_CYCLE_SCORES (ARTICLES)
+    @Async("meinTaskExecutor")
+    public void executeRecalcCycleScoresJob(Long jobId) {
+        AsyncJob job = asyncJobRepository.findById(jobId).orElseThrow();
+
+        try {
+            job.setStatus(AsyncJob.Status.RUNNING);
+            job.setPhase("Preparing");
+            job.setProgressPercent(0);
+            job.setMessage("Starting article recalculation");
+            asyncJobRepository.save(job);
+
+            JsonNode payload = objectMapper.readTree(job.getRequestPayload());
+            long cycleId = payload.get("cycleId").asLong();
+
+            AsyncArticleService.RecalcResult result = articleService.recalcArticleCycleScores(
+                    cycleId,
+                    (progress, phase) -> {
+                        job.setProgressPercent(progress);
+                        job.setPhase(phase);
+                        asyncJobRepository.save(job);
+                    }
+            );
+
+            ObjectNode resultJson = objectMapper.createObjectNode();
+            resultJson.put("updated", result.updated());
+            resultJson.put("unmatched", result.unmatched());
+
+            job.setStatus(AsyncJob.Status.DONE);
+            job.setPhase("Finished");
+            job.setMessage("Article recalculation completed");
+            job.setResultPayload(objectMapper.writeValueAsString(resultJson));
+            job.setProgressPercent(100);
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+
+        } catch (Exception e) {
+            job.setStatus(AsyncJob.Status.FAILED);
+            job.setPhase("Failed");
+            job.setMessage("Article recalculation failed");
+            job.setErrorMessage(e.getMessage());
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+        }
+    }
+
+    @Async("meinTaskExecutor")
+    public void executeDeleteMeinVersionJob(Long jobId) {
+        AsyncJob job = asyncJobRepository.findById(jobId).orElseThrow();
+
+        try {
+            job.setStatus(AsyncJob.Status.RUNNING);
+            job.setPhase("Preparing delete");
+            job.setProgressPercent(0);
+            job.setMessage("Starting MEiN version deletion");
+            asyncJobRepository.save(job);
+
+            JsonNode payload = objectMapper.readTree(job.getRequestPayload());
+            long versionId = payload.get("versionId").asLong();
+
+            tx.executeWithoutResult(status -> {
+                entityManager.createNativeQuery("SET LOCAL synchronous_commit = off")
+                        .executeUpdate();
+
+
+                var cycles = evalCycleRepository.findAllByMeinVersionId(versionId);
+                for (EvalCycle cycle : cycles) {
+                    cycle.setMeinVersion(null);
+                }
+                if (!cycles.isEmpty()) {
+                    evalCycleRepository.saveAll(cycles);
+                }
+
+                var publications = publicationRepository.findAllByMeinVersionId(versionId);
+                for (Publication pub : publications) {
+                    pub.setMeinPoints(0);
+                    pub.setMeinVersionId(null);
+                    pub.setMeinJournalId(null);
+                    pub.setUpdatedAt(Instant.now());
+                }
+                if (!publications.isEmpty()) {
+                    publicationRepository.saveAll(publications);
+                }
+            });
+
+            job.setPhase("Removing MEiN journals");
+            job.setProgressPercent(50);
+            job.setMessage("Removing MEiN journals and version");
+            asyncJobRepository.save(job);
+
+            tx.executeWithoutResult(status -> {
+                entityManager.createNativeQuery("SET LOCAL synchronous_commit = off")
+                        .executeUpdate();
+
+                meinJournalCodeRepository.deleteCodesByVersion(versionId);
+                meinJournalRepository.deleteJournalsByVersion(versionId);
+                meinVersionRepository.deleteById(versionId);
+                meinVersionRepository.flush();
+            });
+
+            ObjectNode resultJson = objectMapper.createObjectNode();
+            resultJson.put("deletedVersionId", versionId);
+
+            job.setStatus(AsyncJob.Status.DONE);
+            job.setPhase("Finished");
+            job.setMessage("MEiN version deletion completed");
+            job.setResultPayload(objectMapper.writeValueAsString(resultJson));
+            job.setProgressPercent(100);
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+
+        } catch (Exception e) {
+            job.setStatus(AsyncJob.Status.FAILED);
+            job.setPhase("Failed");
+            job.setMessage("MEiN version deletion failed");
+            job.setErrorMessage(e.getMessage());
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+        }
+    }
+
+    @Async("meinTaskExecutor")
+    public void executeDeleteMeinMonoVersionJob(Long jobId) {
+        AsyncJob job = asyncJobRepository.findById(jobId).orElseThrow();
+
+        try {
+            job.setStatus(AsyncJob.Status.RUNNING);
+            job.setPhase("Preparing delete");
+            job.setProgressPercent(0);
+            job.setMessage("Starting MeinMonoVersion deletion");
+            asyncJobRepository.save(job);
+
+            JsonNode payload = objectMapper.readTree(job.getRequestPayload());
+            long versionId = payload.get("versionId").asLong();
+
+            tx.executeWithoutResult(status -> {
+                entityManager.createNativeQuery("SET LOCAL synchronous_commit = off")
+                        .executeUpdate();
+
+                List<EvalCycle> cycles = evalCycleRepository.findAllByMeinMonoVersion(versionId);
+                for (EvalCycle cycle : cycles) {
+                    cycle.setMeinMonoVersion(null);
+                }
+                if (!cycles.isEmpty()) {
+                    evalCycleRepository.saveAll(cycles);
+                }
+
+                List<Monographic> monographics = monographicRepository.findAllByMeinMonoId(versionId);
+                for (Monographic m : monographics) {
+                    m.setMeinPoints(0);
+                    m.setMeinMonoId(null);
+                    m.setMeinMonoPublisherId(null);
+                    m.setUpdatedAt(Instant.now());
+                }
+                if (!monographics.isEmpty()) {
+                    monographicRepository.saveAll(monographics);
+                }
+
+                List<MonographChapter> chapters = monographChapterRepository.findAllByMeinMonoId(versionId);
+                for (MonographChapter mc : chapters) {
+                    mc.setMeinPoints(0.0);
+                    mc.setMeinMonoId(null);
+                    mc.setMeinMonoPublisherId(null);
+                    mc.setUpdatedAt(Instant.now());
+                }
+                if (!chapters.isEmpty()) {
+                    monographChapterRepository.saveAll(chapters);
+                }
+            });
+
+            job.setPhase("Removing MeinMonoVersion");
+            job.setProgressPercent(60);
+            job.setMessage("Marking MeinMonoVersion as deleted");
+            asyncJobRepository.save(job);
+
+
+            tx.executeWithoutResult(status -> {
+                entityManager.createNativeQuery("SET LOCAL synchronous_commit = off")
+                        .executeUpdate();
+
+                 meinMonoVersionRepository.deleteById(versionId);
+            });
+
+            ObjectNode resultJson = objectMapper.createObjectNode();
+            resultJson.put("deletedMonoVersionId", versionId);
+
+            job.setStatus(AsyncJob.Status.DONE);
+            job.setPhase("Finished");
+            job.setMessage("MeinMonoVersion deletion completed");
+            job.setResultPayload(objectMapper.writeValueAsString(resultJson));
+            job.setProgressPercent(100);
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+
+        } catch (Exception e) {
+            job.setStatus(AsyncJob.Status.FAILED);
+            job.setPhase("Failed");
+            job.setMessage("MeinMonoVersion deletion failed");
+            job.setErrorMessage(e.getMessage());
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+        }
+    }
+
+    @Async("meinTaskExecutor")
+    public void executeRecalcMonoCycleScoresJob(Long jobId) {
+        AsyncJob job = asyncJobRepository.findById(jobId).orElseThrow();
+
+        try {
+            job.setStatus(AsyncJob.Status.RUNNING);
+            job.setPhase("Preparing mono recalc");
+            job.setProgressPercent(0);
+            job.setMessage("Starting monograph cycle recalculation");
+            asyncJobRepository.save(job);
+
+            JsonNode payload = objectMapper.readTree(job.getRequestPayload());
+            long cycleId = payload.get("cycleId").asLong();
+
+            EvalCycle evalCycle = evalCycleRepository.findById(cycleId)
+                    .orElseThrow(() -> new RuntimeException("EvalCycle not found: " + cycleId));
+
+            Recalculation recalculation = articleService.recalcMonoCycleScoresInternal(evalCycle);
+
+            ObjectNode resultJson = objectMapper.createObjectNode();
+            resultJson.put("updatedMonographs", recalculation.getUpdatedMono());
+            resultJson.put("unmatchedMonographs", recalculation.getUnmatchdMono());
+            resultJson.put("updatedChapters", recalculation.getUpdatedChapter());
+            resultJson.put("unmatchedChapters", recalculation.getUnmatchdChapter());
+
+            job.setStatus(AsyncJob.Status.DONE);
+            job.setPhase("Finished");
+            job.setMessage("Monograph cycle recalculation completed");
+            job.setResultPayload(objectMapper.writeValueAsString(resultJson));
+            job.setProgressPercent(100);
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+
+        } catch (Exception e) {
+            job.setStatus(AsyncJob.Status.FAILED);
+            job.setPhase("Failed");
+            job.setMessage("Monograph cycle recalculation failed");
+            job.setErrorMessage(e.getMessage());
+            job.setFinishedAt(Instant.now());
+            asyncJobRepository.save(job);
+        }
+    }
+}

--- a/article/src/main/java/org/example/article/service/ELTMonoService.java
+++ b/article/src/main/java/org/example/article/service/ELTMonoService.java
@@ -1,19 +1,49 @@
 package org.example.article.service;
 
-import com.example.generated.ETLMonoServiceGrpc;
-import com.example.generated.ImportMEiNReply;
-import com.example.generated.ImportMEiNRequest;
+import com.example.generated.*;
+import com.google.protobuf.Timestamp;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.example.article.ETL.MonoETLService;
+import org.example.article.entities.AsyncJob;
+import org.example.article.entities.MEiN.monographs.MeinMonoPublisher;
+import org.example.article.entities.MEiN.monographs.MeinMonoVersion;
+import org.example.article.helpers.CommutePoints;
+import org.example.article.repositories.*;
+import org.example.article.service.Async.AsyncMeinService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ELTMonoService extends ETLMonoServiceGrpc.ETLMonoServiceImplBase {
 
     private final MonoETLService monoETLService;
+    private final MeinMonoVersionRepository meinMonoVersionRepository;
+    private final MeinMonoPublisherRepository meinMonoPublisherRepository;
+    private final EvalCycleRepository evalCycleRepository;
+    private final MonographicRepository monographicRepository;
+    private final MonographChapterRepository monographChapterRepository;
+    private final CommutePoints commutePoints;
+    private final AsyncJobRepository asyncJobRepository;
+    private final AsyncMeinService asyncMeinService;
 
-    public ELTMonoService(MonoETLService monoETLService) {
+    public ELTMonoService(MonoETLService monoETLService, MeinMonoVersionRepository meinMonoVersionRepository, MeinMonoPublisherRepository meinMonoPublisherRepository, EvalCycleRepository evalCycleRepository, MonographicRepository monographicRepository, MonographChapterRepository monographChapterRepository, CommutePoints commutePoints, AsyncJobRepository asyncJobRepository, AsyncMeinService asyncMeinService) {
         this.monoETLService = monoETLService;
+        this.meinMonoVersionRepository = meinMonoVersionRepository;
+        this.meinMonoPublisherRepository = meinMonoPublisherRepository;
+        this.evalCycleRepository = evalCycleRepository;
+        this.monographicRepository = monographicRepository;
+        this.monographChapterRepository = monographChapterRepository;
+        this.commutePoints = commutePoints;
+        this.asyncJobRepository = asyncJobRepository;
+        this.asyncMeinService = asyncMeinService;
     }
 
     @Override
@@ -44,4 +74,323 @@ public class ELTMonoService extends ETLMonoServiceGrpc.ETLMonoServiceImplBase {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void adminGetMeinMonoVersion(AdminGetMeinMonoVersionRequest request, StreamObserver<AdminGetMeinMonoVersionResponse> responseObserver) {
+        Long versionId = request.getId();
+
+        MeinMonoVersion meinMonoVersion = meinMonoVersionRepository.findById(versionId)
+                .orElseThrow(() -> new RuntimeException("Mein version mono not found"));
+
+        long countPublishers = meinMonoPublisherRepository.countPublishers(meinMonoVersion.getId());
+
+        Instant instant = meinMonoVersion.getImportedAt();
+        Timestamp time = Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
+
+        MeinMonoVersionItem item = MeinMonoVersionItem.newBuilder()
+                .setId(meinMonoVersion.getId())
+                .setLabel(meinMonoVersion.getLabel())
+                .setSourceFilename(meinMonoVersion.getSourceFilename())
+                .setImportedBy(meinMonoVersion.getImportedBy())
+                .setImportedAt(time)
+                .setPublishers(countPublishers)
+                .build();
+
+        AdminGetMeinMonoVersionResponse response = AdminGetMeinMonoVersionResponse.newBuilder()
+                .setVersion(item).build();
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+
+
+    }
+
+    @Override
+    public void adminGetMeinMonoPublisher(AdminGetMeinMonoPublisherRequest request, StreamObserver<AdminGetMeinMonoPublisherResponse> responseObserver) {
+        Long publisherId = request.getId();
+
+        MeinMonoPublisher meinMonoPublisher = meinMonoPublisherRepository.findById(publisherId).orElseThrow(() -> new RuntimeException("Mein publisher not found"));
+
+
+        MeinMonoPublisherItem item = MeinMonoPublisherItem.newBuilder()
+                .setId(meinMonoPublisher.getId())
+                .setTitle(meinMonoPublisher.getName())
+                .setPoints(meinMonoPublisher.getPoints())
+                .setLevel(meinMonoPublisher.getLevel())
+                .setVersionId(meinMonoPublisher.getVersion().getId())
+                .build();
+
+        AdminGetMeinMonoPublisherResponse response = AdminGetMeinMonoPublisherResponse.newBuilder()
+                .setPublisher(item).build();
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void adminListMeinMonoVersions(AdminListMeinMonoVersionsRequest request, StreamObserver<AdminListMeinMonoVersionsResponse> responseObserver) {
+        int pg = Math.max(0, request.getPage());
+        int sz = request.getSize() > 0 ? Math.min(request.getSize(), 100) : 20;
+
+        boolean desc = !"ASC".equalsIgnoreCase(request.getSortDir());
+        Sort sort = Sort.by(desc ? Sort.Direction.DESC : Sort.Direction.ASC, "importedAt");
+        Pageable pageable = PageRequest.of(pg, sz, sort);
+
+        Page<MeinMonoVersion> page = meinMonoVersionRepository.findAll(pageable);
+
+        PageMeta pageMeta = PageMeta.newBuilder()
+                .setPage(page.getNumber())
+                .setTotalPages(page.getTotalPages())
+                .setSize(page.getSize())
+                .setTotalItems(page.getTotalElements())
+                .build();
+
+        AdminListMeinMonoVersionsResponse.Builder response = AdminListMeinMonoVersionsResponse.newBuilder()
+                .setPage(pageMeta);
+
+        for(MeinMonoVersion version : page.getContent()) {
+
+            long publisers = meinMonoPublisherRepository.countPublishers(version.getId());
+
+            Instant instant = version.getImportedAt();
+            Timestamp time = Timestamp.newBuilder()
+                    .setSeconds(instant.getEpochSecond())
+                    .setNanos(instant.getNano())
+                    .build();
+
+
+            response.addItems(MeinMonoVersionItem.newBuilder()
+                    .setId(version.getId())
+                    .setLabel(version.getLabel())
+                    .setSourceFilename(version.getSourceFilename())
+                    .setImportedBy(version.getImportedBy())
+                    .setImportedAt(time)
+                    .setPublishers(publisers)
+                    .build());
+
+        }
+
+        responseObserver.onNext(response.build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void adminListMeinMonoPublishers(AdminListMeinMonoPublishersRequest request, StreamObserver<AdminListMeinMonoPublishersResponse> responseObserver) {
+        long versionId = request.getVersionId();
+
+        if(!meinMonoVersionRepository.existsById(versionId)) {
+            responseObserver.onError(Status.NOT_FOUND.withDescription("Not found the mein mono version").asRuntimeException());
+            return;
+        }
+
+        int pg = Math.max(0, request.getPage());
+        int sz = request.getSize() > 0 ? Math.min(request.getSize(), 100) : 20;
+
+        boolean desc = !"ASC".equalsIgnoreCase(request.getSortDir());
+        Sort sort = Sort.by(desc ? Sort.Direction.DESC : Sort.Direction.ASC, "level");
+        Pageable pageable = PageRequest.of(pg, sz, sort);
+
+        Page<MeinMonoPublisher> page = meinMonoPublisherRepository.findByVersion_Id(versionId, pageable);
+
+        PageMeta pageMeta = PageMeta.newBuilder()
+                .setSize(page.getSize())
+                .setPage(page.getNumber())
+                .setTotalItems(page.getTotalElements())
+                .setTotalPages(page.getTotalPages())
+                .build();
+
+        AdminListMeinMonoPublishersResponse.Builder response = AdminListMeinMonoPublishersResponse.newBuilder()
+                .setPageMeta(pageMeta);
+
+        for(MeinMonoPublisher publisher : page.getContent()) {
+            response.addItems(MeinMonoPublisherItem.newBuilder()
+                    .setId(publisher.getId())
+                    .setTitle(publisher.getName())
+                    .setPoints(publisher.getPoints())
+                    .setLevel(publisher.getLevel())
+                    .setVersionId(publisher.getVersion().getId())
+                    .build());
+
+        }
+
+        responseObserver.onNext(response.build());
+        responseObserver.onCompleted();
+        }
+
+//    @Override
+//    public void adminDeleteMeinMonoVersion(DeleteMeinMonoVersionRequest request, StreamObserver<ApiResponse> responseObserver) {
+//        long versionId = request.getId();
+//
+//        if(!meinMonoVersionRepository.existsById(versionId)) {
+//            responseObserver.onError(Status.NOT_FOUND
+//                    .withDescription("No mein version with this id").asRuntimeException());
+//            return;
+//        }
+//
+//        List<EvalCycle> cycles = evalCycleRepository.findAllByMeinMonoVersion(versionId);
+//        for (EvalCycle cycle : cycles) {
+//            cycle.setMeinMonoVersion(null);
+//        }
+//        if (!cycles.isEmpty()) {
+//            evalCycleRepository.saveAll(cycles);
+//        }
+//        // 2. Wyczyść publikacje powiązane z tą wersją MEiN
+//        // (monografie i rozdziały)
+//        List<Monographic> monographics = monographicRepository.findAllByMeinMonoId(versionId);
+//        for (Monographic m : monographics) {
+//            m.setMeinPoints(0);
+//            m.setMeinMonoId(null);
+//            m.setMeinMonoPublisherId(null);
+//            m.setUpdatedAt(Instant.now());
+//        }
+//        if (!monographics.isEmpty()) {
+//            monographicRepository.saveAll(monographics);
+//        }
+//
+//        List<MonographChapter> chapters = monographChapterRepository.findAllByMeinMonoId(versionId);
+//        for (MonographChapter mc : chapters) {
+//            mc.setMeinPoints(0.0);
+//            mc.setMeinMonoId(null);
+//            mc.setMeinMonoPublisherId(null);
+//            mc.setUpdatedAt(Instant.now());
+//        }
+//        if (!chapters.isEmpty()) {
+//            monographChapterRepository.saveAll(chapters);
+//        }
+//
+//
+//        evalCycleRepository.saveAll(cycles);
+//        meinMonoVersionRepository.deleteById(versionId);
+//
+//
+//        ApiResponse response = ApiResponse.newBuilder()
+//                .setCode(200)
+//                .setMessage("Successfully deleted ")
+//                .build();
+//
+//        responseObserver.onNext(response);
+//        responseObserver.onCompleted();
+//
+//    }
+@Override
+public void adminDeleteMeinMonoVersion(DeleteMeinMonoVersionRequest request,
+                                       StreamObserver<ApiResponse> responseObserver) {
+    long versionId = request.getId();
+
+    if (!meinMonoVersionRepository.existsById(versionId)) {
+        responseObserver.onError(Status.NOT_FOUND
+                .withDescription("No MeinMonoVersion with this id")
+                .asRuntimeException());
+        return;
+    }
+
+    String businessKey = "DELETE_MEIN_MONO_VERSION:" + versionId;
+
+    Optional<AsyncJob> existingJobOpt =
+            asyncJobRepository.findFirstByTypeAndBusinessKeyAndStatusIn(
+                    "DELETE_MEIN_MONO_VERSION",
+                    businessKey,
+                    List.of(AsyncJob.Status.QUEUED, AsyncJob.Status.RUNNING)
+            );
+
+    AsyncJob job;
+    if (existingJobOpt.isPresent()) {
+        job = existingJobOpt.get();
+    } else {
+        job = new AsyncJob();
+        job.setType("DELETE_MEIN_MONO_VERSION");
+        job.setBusinessKey(businessKey);
+        job.setStatus(AsyncJob.Status.QUEUED);
+        job.setProgressPercent(0);
+        job.setPhase("Queued");
+        job.setMessage("Waiting to start MeinMonoVersion deletion");
+        job.setRequestPayload("{\"versionId\": " + versionId + "}");
+        job.setCreatedAt(Instant.now());
+        asyncJobRepository.save(job);
+
+        asyncMeinService.executeDeleteMeinMonoVersionJob(job.getId());
+    }
+
+    ApiResponse response = ApiResponse.newBuilder()
+            .setCode(200)
+            .setMessage("MeinMonoVersion deletion started or already in progress. JobId=" + job.getId())
+            .build();
+
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+}
+//    @Override
+//    public void adminRecalculateMonoCycleScores(AdminRecalcMonoCycleScoresRequest request, StreamObserver<AdminRecalcMonoCycleScoresResponse> responseObserver) {
+//        Long cycleId = request.getCycleId();
+//
+//        if(!evalCycleRepository.existsById(cycleId)){
+//            responseObserver.onError(Status.NOT_FOUND.withDescription("Not found the cycle").asRuntimeException());
+//            return;
+//        }
+//
+//        EvalCycle evalCycle = evalCycleRepository.findById(cycleId).orElseThrow(()-> new RuntimeException("Not found the cycle"));
+//
+//        Recalculation recalculation = recalcMonoCycleScoresInternal(evalCycle);
+//
+//        AdminRecalcMonoCycleScoresResponse response = AdminRecalcMonoCycleScoresResponse.newBuilder()
+//                .setUpdatedMonographs(recalculation.getUpdatedMono())
+//                .setUnmatchedMonographs(recalculation.getUnmatchdMono())
+//                .setUpdatedChapters(recalculation.getUpdatedChapter())
+//                .setUnmatchedChapters(recalculation.getUnmatchdChapter())
+//                .build();
+//
+//        responseObserver.onNext(response);
+//        responseObserver.onCompleted();
+//    }
+@Override
+public void adminRecalculateMonoCycleScores(AdminRecalcMonoCycleScoresRequest request,
+                                            StreamObserver<AdminRecalcMonoCycleScoresResponse> responseObserver) {
+    Long cycleId = request.getCycleId();
+
+    if (!evalCycleRepository.existsById(cycleId)) {
+        responseObserver.onError(Status.NOT_FOUND
+                .withDescription("Not found the cycle")
+                .asRuntimeException());
+        return;
+    }
+
+    String businessKey = "RECALC_MONO_CYCLE_SCORES:" + cycleId;
+
+    Optional<AsyncJob> existingJobOpt =
+            asyncJobRepository.findFirstByTypeAndBusinessKeyAndStatusIn(
+                    "RECALC_MONO_CYCLE_SCORES",
+                    businessKey,
+                    List.of(AsyncJob.Status.QUEUED, AsyncJob.Status.RUNNING)
+            );
+
+    AsyncJob job;
+    if (existingJobOpt.isPresent()) {
+        job = existingJobOpt.get();
+    } else {
+        job = new AsyncJob();
+        job.setType("RECALC_MONO_CYCLE_SCORES");
+        job.setBusinessKey(businessKey);
+        job.setStatus(AsyncJob.Status.QUEUED);
+        job.setProgressPercent(0);
+        job.setPhase("Queued");
+        job.setMessage("Waiting to start monograph cycle recalculation");
+        job.setRequestPayload("{\"cycleId\": " + cycleId + "}");
+        job.setCreatedAt(Instant.now());
+        asyncJobRepository.save(job);
+
+        asyncMeinService.executeRecalcMonoCycleScoresJob(job.getId());
+    }
+
+    AdminRecalcMonoCycleScoresResponse response =
+            AdminRecalcMonoCycleScoresResponse.newBuilder()
+                    .setJobId(job.getId())
+                    .setMessage("Monograph cycle recalculation started or already in progress")
+                    .build();
+
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+}
 }

--- a/article/src/main/proto/api_article.proto
+++ b/article/src/main/proto/api_article.proto
@@ -48,6 +48,7 @@ message AdminListMeinVersionsResponse {
 message AdminGetMeinVersionRequest {
   int64 version_id=1;
 }
+
 message AdminGetMeinVersionResponse {
   MeinVersionItem version=1;
   int64 distinctIssn   = 2;
@@ -89,7 +90,6 @@ message AdminListMeinJournalsRequest {
   int32 page = 6;               // 0-based
   int32 size = 7;               // domyślnie 20, max 100
   string sortDir = 9;           // "ASC"|"DESC" (domyślnie ASC)
-
 }
 message AdminListMeinJournalsResponse {
   repeated MeinJournalItem items = 1;
@@ -126,8 +126,10 @@ message AdminRecalcCycleScoresRequest {
 }
 
 message AdminRecalcCycleScoresResponse {
-  int32 updated_publications = 1;
-  int32 unmatched_publications = 2;
+//  int32 updated_publications = 1;
+//  int32 unmatched_publications = 2;
+  int64 job_id = 1;
+  string message = 2;
 }
 
 //publications
@@ -371,6 +373,10 @@ message ApiResponse {
   string message = 2;
 }
 
+message DeleteMeinVersionResponse {
+  int64 job_id = 1;
+  string message = 2;
+}
 message CreateMonographRequest{
   int64 userId = 1;
 
@@ -527,6 +533,80 @@ message DeleteChapterRequest{
   int64 userId = 2;
 }
 
+message MeinMonoVersionItem {
+  int64 id=1;
+  string label=2;
+  string sourceFilename=3;
+  int64 importedBy=5;
+  google.protobuf.Timestamp importedAt=6;
+  int64 publishers =8;
+}
+
+message MeinMonoPublisherItem {
+  int64 id = 1;
+  string title = 2;
+  double points = 3;
+  int64 version_id = 4;
+  string level = 5;
+}
+
+message AdminListMeinMonoVersionsRequest {
+  int32 page = 1;
+  int32 size = 2;
+  string sortDir = 3;
+}
+
+message AdminListMeinMonoVersionsResponse {
+  repeated MeinMonoVersionItem items = 1;
+  PageMeta page = 2;
+}
+
+message AdminGetMeinMonoVersionRequest {
+  int64 id = 1;
+}
+
+message AdminGetMeinMonoVersionResponse {
+  MeinMonoVersionItem version = 1;
+}
+
+message DeleteMeinMonoVersionRequest {
+  int64 id = 1;
+}
+
+message AdminListMeinMonoPublishersRequest {
+  int64 version_id = 1;   
+  int32 page = 2;
+  int32 size = 3;
+  string sortDir = 9;
+
+}
+
+message AdminListMeinMonoPublishersResponse {
+  repeated MeinMonoPublisherItem items = 1;
+  PageMeta pageMeta = 2;
+}
+
+message AdminGetMeinMonoPublisherRequest {
+  int64 id = 1;
+}
+
+message AdminGetMeinMonoPublisherResponse {
+  MeinMonoPublisherItem publisher = 1;
+}
+
+message AdminRecalcMonoCycleScoresRequest {
+  int64 cycle_id = 1;
+}
+
+message AdminRecalcMonoCycleScoresResponse {
+//  int64 updated_monographs = 1;
+//  int64 updated_chapters = 2;
+//  int64 unmatched_monographs = 3;
+//  int64 unmatched_chapters = 4;
+  int64 job_id = 5;
+  string message = 6;
+}
+
 
 service WorkerArticleService{
   rpc CreatePublication(CreatePublicationRequest) returns (PublicationView);
@@ -567,9 +647,34 @@ service ArticleService{
   rpc ListDisciplines(google.protobuf.Empty) returns (ListDisciplinesResponse);
   rpc ListEvalCycles(google.protobuf.Empty) returns (ListCyclesResponse);
 }
+message GetJobStatusRequest {
+  int64 job_id = 1;
+}
 
+message GetJobStatusResponse {
+  int64 job_id = 1;
+  string type = 2;
+  string status = 3;          // "QUEUED", "RUNNING", "DONE", "FAILED"
+  int32 progress_percent = 4;
+  string phase = 5;
+  string message = 6;
+  string result_json = 7;
+  string error = 8;
+}
+//TODO: think about active mono version to find from active eval cycle
 service ETLMonoService{
   rpc ImportFile(ImportMEiNRequest) returns (ImportMEiNReply);
+  // versions
+  rpc AdminListMeinMonoVersions(AdminListMeinMonoVersionsRequest) returns (AdminListMeinMonoVersionsResponse);
+  rpc AdminGetMeinMonoVersion(AdminGetMeinMonoVersionRequest) returns (AdminGetMeinMonoVersionResponse);
+  rpc AdminDeleteMeinMonoVersion(DeleteMeinMonoVersionRequest) returns (ApiResponse);
+
+  // publishers (equivalent of journals)
+  rpc AdminListMeinMonoPublishers(AdminListMeinMonoPublishersRequest) returns (AdminListMeinMonoPublishersResponse);
+  rpc AdminGetMeinMonoPublisher(AdminGetMeinMonoPublisherRequest) returns (AdminGetMeinMonoPublisherResponse);
+
+  // recalc scores for cycles based on mono list
+  rpc AdminRecalculateMonoCycleScores(AdminRecalcMonoCycleScoresRequest) returns (AdminRecalcMonoCycleScoresResponse);
 }
 service ETLArticleService{
   rpc ImportFile(ImportMEiNRequest) returns (ImportMEiNReply);
@@ -580,8 +685,9 @@ service ETLArticleService{
   rpc AdminGetMeinJournal(AdminGetMeinJournalRequest) returns (AdminGetMeinJournalResponse);
   rpc AdminActivateMeinVersion(ActivateMeinVersionRequest) returns (ApiResponse);
   rpc AdminDeactivateMeinVersion(DeactivateMeinVersionRequest) returns (ApiResponse);
-  rpc AdminDeleteMeinVersion(DeleteMeinVersionRequest) returns (ApiResponse);
+  rpc AdminDeleteMeinVersion(DeleteMeinVersionRequest) returns (DeleteMeinVersionResponse);
   rpc AdminRecalculateCycleScores(AdminRecalcCycleScoresRequest) returns (AdminRecalcCycleScoresResponse);
+  rpc AdminGetJobStats(GetJobStatusRequest) returns (GetJobStatusResponse);
 }
 
 service WorkerMonographService {
@@ -601,7 +707,7 @@ service WorkerMonographService {
 }
 
 service AdminMonographService {
-//  // monographs
+  // monographs
 //  rpc AdminListMonographs(ListAdminMonographsRequest) returns (ListMonographsResponse);
 //  rpc AdminGetMonograph(GetMonographRequest) returns (MonographView);
 //

--- a/article/src/main/resources/db/migration/V14__addAsyncJob.sql
+++ b/article/src/main/resources/db/migration/V14__addAsyncJob.sql
@@ -1,0 +1,22 @@
+CREATE TABLE async_job (
+                           id                BIGSERIAL PRIMARY KEY,
+
+                           type              VARCHAR(100) NOT NULL,          -- np. "RECALC_CYCLE_SCORES", "DELETE_MEIN_VERSION"
+                           status            VARCHAR(20)  NOT NULL,          -- "QUEUED", "RUNNING", "DONE", "FAILED"
+
+                           progress_percent  INTEGER,                        -- 0–100
+                           phase             VARCHAR(255),                   -- np. "Deleting journals", "Recalculating scores"
+                           message           VARCHAR(255),                   -- krótki opis dla UI
+
+                           request_payload   TEXT,                           -- JSON: np. {"cycleId": 123}
+                           result_payload    TEXT,                           -- JSON: np. {"updated": 100, "unmatched": 20}
+
+                           error_message     TEXT,
+
+                           created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+                           finished_at       TIMESTAMPTZ
+);
+
+CREATE INDEX idx_async_job_type ON async_job(type);
+CREATE INDEX idx_async_job_status ON async_job(status);
+CREATE INDEX idx_async_job_created_at ON async_job(created_at);

--- a/article/src/main/resources/db/migration/V15__alterAsync.sql
+++ b/article/src/main/resources/db/migration/V15__alterAsync.sql
@@ -1,0 +1,5 @@
+ALTER TABLE async_job
+    ADD COLUMN business_key VARCHAR(200);
+
+CREATE INDEX idx_async_job_business_key
+    ON async_job(business_key);


### PR DESCRIPTION
## Summary

Introduce asynchronous background jobs for MEiN operations (articles and monographs) and hook recalculation into evaluation cycle updates when MEiN versions change.

## Changes

- Added `AsyncJob` entity + repository to track long-running operations:
  - Type (`RECALC_CYCLE_SCORES`, `RECALC_MONO_CYCLE_SCORES`, `DELETE_MEIN_VERSION`, `DELETE_MEIN_MONO_VERSION`)
  - Status (`QUEUED`, `RUNNING`, `DONE`, `FAILED`)
  - Progress, phase, message
  - JSON request/result payload
- Added `businessKey` to `AsyncJob` and lookup in `AsyncJobRepository` to make job creation idempotent per operation (e.g. one job per cycle/version).

### Articles (MEiN article version)

- Implemented `AsyncMeinService.executeRecalcCycleScoresJob(jobId)` to:
  - Load cycle from `requestPayload.cycleId`
  - Run article score recalculation in background
  - Update job progress and store result summary (updated/unmatched) in `resultPayload`.
- Implemented `AsyncMeinService.executeDeleteMeinVersionJob(jobId)` to:
  - Load versionId from `requestPayload`
  - Detach `EvalCycle.meinVersion` for all affected cycles
  - Reset related publications:
    - `meinPoints = 0`
    - `meinVersionId = null`
    - `meinJournalId = null`
  - Remove related MEiN data (journals, codes, version) or mark as deleted (depending on config)
  - Update job status/progress.

### Monographs (MEiN mono version)

- Updated `adminDeleteMeinMonoVersion` to use an async job:
  - Detach `EvalCycle.meinMonoVersion`
  - Reset MEiN fields for `Monographic` and `MonographChapter`:
    - `meinPoints = 0` / `0.0`
    - `meinMonoId = null`
    - `meinMonoPublisherId = null`
  - Then delete / soft-delete the corresponding `MeinMonoVersion`.
- Added `AsyncMeinService.executeRecalcMonoCycleScoresJob(jobId)`:
  - Runs existing `recalcMonoCycleScoresInternal` logic in background
  - Stores updated/unmatched counts for monographs and chapters in `resultPayload`.

### EvalCycle updates

- Extended `adminUpdateEvalCycle` to:
  - Correctly handle nullable `meinVersion` / `meinMonoVersion` and ID access (no NPEs).
  - Track old vs new `meinVersionId` and `monoVersionId`.
  - After saving the cycle:
    - If `meinVersionId` changed → schedule `RECALC_CYCLE_SCORES` async job for that cycle.
    - If `monoVersionId` changed → schedule `RECALC_MONO_CYCLE_SCORES` async job for that cycle.
- Added helper methods:
  - `scheduleArticleRecalcJob(cycleId)`
  - `scheduleMonoRecalcJob(cycleId)`
  which create `AsyncJob`s only if there is no existing `QUEUED/RUNNING` job with the same `businessKey`.

## Behaviour

- Deleting MEiN versions (article/mono) no longer blocks the request while data is processed; work is done in background via async jobs.
- Publications / monographs and chapters are left in a consistent state after version removal (no FK violations, MEiN fields reset).
- Changing MEiN version on an evaluation cycle will automatically trigger asynchronous recalculation of the affected scores.
- All long-running operations can be tracked via `AsyncJob` (status, progress, result).